### PR TITLE
Hide the internal syntaxes

### DIFF
--- a/Inno Pascal.sublime-syntax
+++ b/Inno Pascal.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: 'Inno Pascal'
 scope: source.pascal.inno
+hidden: true
 
 variables:
   keywords: '\b(?i:and|array|as|begin|break|case|const|continue|div|do|downto|else|end|except|exit|external|finally|for|forward|function|goto|if|in|interface|is|label|mod|not|of|or|out|procedure|program|record|repeat|set|shl|shr|then|to|try|type|until|var|while|with|xor)\b'

--- a/Inno Preprocessor.sublime-syntax
+++ b/Inno Preprocessor.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: 'Inno Preprocessor'
 scope: meta.preprocessor.inno
+hidden: true
 
 variables:
   directives: '(?:[:+=!]|\b(?i:append|define|dim|elif|else|emit|endif|endsub|error|expr|file|for|if|ifn?def|ifn?exist|include|insert|pragma|preproc|redim|sub|undef|x)\b)'


### PR DESCRIPTION
There is no need to clutter the syntax menu with internal Inno Setup syntaxes.